### PR TITLE
update demo links to use github relative path markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ to the ```appFiles``` and ```specFiles``` arrays, respectively. (I'm planning to
 
 ### MultiSelect
 
-MultiSelect provides the familiar file-system style hotkey selection strategy. See [demo/multi-select](https://github.com/jamesBrennan/akop/blob/master/demo/multi-select.html) for a
+MultiSelect provides the familiar file-system style hotkey selection strategy. See [demo/multi-select](demo/multi-select.html) for a
 basic implementation.
 
 ## Filters
 
 ### QueryFilter
 
-The Query filter provides an enhanced interface for filtering collections. See [demo/query-filter](https://github.com/jamesBrennan/akop/blob/master/demo/query-filter.html).
+The Query filter provides an enhanced interface for filtering collections. See [demo/query-filter](demo/query-filter.html).


### PR DESCRIPTION
remove links to JamesBrennan github in favor of relative links.

Looks like a couple of good modules.   I feel like I have a few of these that I continually crib from project to project.  Maybe I'll add to this at somepoint - if we all don't drop angular for the react band wagon.

Ref: https://github.com/blog/1395-relative-links-in-markup-files
